### PR TITLE
Ensure that the effect is only applied once

### DIFF
--- a/react-hooks/src/KeyCode4.js
+++ b/react-hooks/src/KeyCode4.js
@@ -8,7 +8,7 @@ const useDocumentKeyCode = () => {
       setCodes({ keyCode, key, code });
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  });
+  }, []);
   return codes;
 };
 


### PR DESCRIPTION
From the docs: If you want to run an effect and run it only once, you can pass an empty array ([]) as a second argument. This tells React that your effect doesn’t depend on any values from props or state, so it never needs to re-run. This isn’t handled as a special case — it follows directly from how the inputs array always works.